### PR TITLE
修复“蜡”读音

### DIFF
--- a/flypy_flypy.dict.yaml
+++ b/flypy_flypy.dict.yaml
@@ -25131,10 +25131,8 @@ use_preset_vocabulary: true
 蜟	yu[[
 蜠	jy[[
 蜠	qy[[
-蜡	ia[io
-蜡	la[io	0%
-蜡	qu[io	50%
-蜡	va[io	50%
+蜡	la[ig
+蜡	va[ig
 蜢	mg[im
 蜣	ql[iv
 蜤	si[[

--- a/flypy_zrmfast.dict.yaml
+++ b/flypy_zrmfast.dict.yaml
@@ -25132,10 +25132,8 @@ use_preset_vocabulary: true
 蜟	yu[[
 蜠	jy[[
 蜠	qy[[
-蜡	ia[ig
-蜡	la[ig	0%
-蜡	qu[ig	50%
-蜡	va[ig	50%
+蜡	la[ig
+蜡	va[ig
 蜢	mg[iz
 蜣	ql[iy
 蜤	si[[


### PR DESCRIPTION
蜡 只有2个读音。错误的发音会引起重码

là
释义
1.动物、植物所产生的或矿物所含的油质。常温下多为固体，具有可塑性，能燃烧，易熔化，不溶于水，可用做防水剂，也可做蜡烛。

zhà
释义
1.古代一种年终祭祀。

